### PR TITLE
Add support for binary encoding

### DIFF
--- a/dcode
+++ b/dcode
@@ -14,6 +14,7 @@ else:
     from urllib import urlopen,unquote,urlencode
 from re import search
 from base64 import  b64decode
+import binascii
 import sys
 import argparse
 
@@ -234,6 +235,23 @@ def base64(string, base):
     decode(base, 'b64')
     Quit()
 
+def int_to_bytes(i):
+    hex_string = '%x' % i
+    n = len(hex_string)
+    return binascii.unhexlify(hex_string.zfill(n + (n & 1)))
+
+def bin_to_ascii(string, base):
+    n = int(string, 2)
+    string = int_to_bytes(n).decode()
+    string = ensure_str(string)
+    if string in decoded:
+        Quit()
+    print(g + ' Decoded from Binary : %s' % (string))
+    decoded.append(string)
+    decode(string, 'none')
+    decode(base, 'binary')
+    Quit()
+
 def decimal(string, base):
     calculated = []
     string = ensure_str(string)
@@ -263,6 +281,9 @@ def decode(string, stop):
     global loop
     if check_ascii(string):
         base = string
+        binary = search(r'^[01]+$', string)
+        if binary and stop != 'binary':
+            bin_to_ascii(string, base)
         sha2 = search(r'^([a-f0-9]{64})$', string)
         if sha2 and not sensitive and stop != 'sha2':
             SHA2(string, base)


### PR DESCRIPTION
Hi,

I think it is useful to add support for Binary encoded strings.

What do you think?

Your example with binary addition:
```
dcode 010011100110101001001101001100110101100101010100010100010111100101001110011110100101000100110001010110010101010001010001001100000100111001000111010101010111101001001101011001110011110100111101

    __                         __      
  |/  |                   | / /        
  |   | ___  ___  ___  ___|  (         
  |   )|___)|    |   )|   )| |___ \   )
  |__/ |__  |__  |__/ |__/ | |     \_/ 
                                    /  
[+] Decoded from Binary : NjM3YTQyNzQ1YTQ0NGUzMg==
[+] Decoded from Base64 : 637a42745a444e32
[+] Decoded from Hex : czBtZDN2
[+] Decoded from Base64 : s0md3v
```

Thanks,
Thanos